### PR TITLE
Change to the new artifactory domain

### DIFF
--- a/examples/example-simple-spring-boot-webapp-ee/pom.xml
+++ b/examples/example-simple-spring-boot-webapp-ee/pom.xml
@@ -67,7 +67,7 @@
     <repository>
       <id>camunda-bpm-ee</id>
       <name>camunda-bpm-ee</name>
-      <url>https://app.camunda.com/nexus/content/repositories/camunda-bpm-ee</url>
+      <url>https://artifacts.camunda.com/artifactory/camunda-bpm-ee/</url>
     </repository>
   </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -98,12 +98,12 @@
     <repository>
       <id>camunda-nexus</id>
       <name>camunda bpm community extensions</name>
-      <url>https://app.camunda.com/nexus/content/repositories/camunda-bpm-community-extensions</url>
+      <url>https://artifacts.camunda.com/artifactory/camunda-bpm-community-extensions/</url>
     </repository>
     <snapshotRepository>
       <id>camunda-nexus</id>
       <name>camunda bpm community extensions snapshots</name>
-      <url>https://app.camunda.com/nexus/content/repositories/camunda-bpm-community-extensions-snapshots</url>
+      <url>https://artifacts.camunda.com/artifactory/camunda-bpm-community-extensions-snapshots/</url>
       <!-- for maven 2 compatibility -->
       <uniqueVersion>true</uniqueVersion>
     </snapshotRepository>


### PR DESCRIPTION
As announced in [#engineering](https://camunda.slack.com/archives/C01H4NG9XDY/p1648023935192419) slack channel, we created a new Artifactory domain since the nexus one used now is a proxy URL and will be removed in the future. 

Related to INFRA-3106